### PR TITLE
DT-1399 - Add ability to cancel task by RXPromise for Oscar (#9)

### DIFF
--- a/Oscar.podspec
+++ b/Oscar.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Oscar"
-  s.version          = "1.0.5"
+  s.version          = "1.0.6"
   s.summary          = "Actor programming model framework"
 
   s.description      = "The actor model in computer science is a mathematical model of concurrent computation that treats \"actors\" as the universal primitives of concurrent computation: in response to a message that it receives, an actor can make local decisions, create more actors, send more messages, and determine how to respond to the next message received.(Wikipedia)"

--- a/Oscar.xcodeproj/project.pbxproj
+++ b/Oscar.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
+		EB8669451DA6A74C0097176E /* OSCancellableActor.m in Sources */ = {isa = PBXBuildFile; fileRef = EB8669441DA6A74C0097176E /* OSCancellableActor.m */; };
+		EB8669471DA6A7540097176E /* OSActorFutureCancellationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EB8669461DA6A7540097176E /* OSActorFutureCancellationTest.m */; };
 		EF7C10BE1D4A3ED900ED0366 /* RXPromise.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF7C10BC1D4A3ED900ED0366 /* RXPromise.framework */; };
 		EF7C10BF1D4A3ED900ED0366 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF7C10BD1D4A3ED900ED0366 /* CocoaLumberjack.framework */; };
 		EF7C10C01D4A3EDE00ED0366 /* RXPromise.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF7C10BC1D4A3ED900ED0366 /* RXPromise.framework */; };
@@ -146,6 +148,9 @@
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Tests-Prefix.pch"; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		EB8669431DA6A74C0097176E /* OSCancellableActor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSCancellableActor.h; sourceTree = "<group>"; };
+		EB8669441DA6A74C0097176E /* OSCancellableActor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSCancellableActor.m; sourceTree = "<group>"; };
+		EB8669461DA6A7540097176E /* OSActorFutureCancellationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSActorFutureCancellationTest.m; sourceTree = "<group>"; };
 		EF7C10BC1D4A3ED900ED0366 /* RXPromise.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RXPromise.framework; path = Carthage/Build/iOS/RXPromise.framework; sourceTree = "<group>"; };
 		EF7C10BD1D4A3ED900ED0366 /* CocoaLumberjack.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CocoaLumberjack.framework; path = Carthage/Build/iOS/CocoaLumberjack.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -320,6 +325,8 @@
 		6003F5B5195388D20070C39A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				EB8669421DA6A74C0097176E /* OSCancellableActor */,
+				EB8669461DA6A7540097176E /* OSActorFutureCancellationTest.m */,
 				4DC00B911B8630D90037BA74 /* OSActorSystemMock.h */,
 				4DC00B921B8630D90037BA74 /* OSActorSystemMock.m */,
 				4DC00B8D1B8630B80037BA74 /* Promise Matcher */,
@@ -346,6 +353,15 @@
 				606FC2411953D9B200FFA9A0 /* Tests-Prefix.pch */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		EB8669421DA6A74C0097176E /* OSCancellableActor */ = {
+			isa = PBXGroup;
+			children = (
+				EB8669431DA6A74C0097176E /* OSCancellableActor.h */,
+				EB8669441DA6A74C0097176E /* OSCancellableActor.m */,
+			);
+			path = OSCancellableActor;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -590,8 +606,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EB8669451DA6A74C0097176E /* OSCancellableActor.m in Sources */,
 				6003F59E195388D20070C39A /* OSAppDelegate.m in Sources */,
 				6003F5A7195388D20070C39A /* OSViewController.m in Sources */,
+				EB8669471DA6A7540097176E /* OSActorFutureCancellationTest.m in Sources */,
 				6003F59A195388D20070C39A /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/OSActorFutureCancellationTest.m
+++ b/Tests/OSActorFutureCancellationTest.m
@@ -1,0 +1,96 @@
+#import <Kiwi/Kiwi.h>
+// Class under test
+#import "OSCancellableActor.h"
+#import "OSActorSystemMock.h"
+
+// Integration test on promise control
+SPEC_BEGIN(OSActorFutureCancellationTest)
+
+
+
+describe(@"Cancellation", ^() {
+
+    OSCancellableActor __block *sut = nil;
+    OSActorRef __block *actorRef = nil;
+    
+    beforeEach(^{
+        sut = [[OSCancellableActor alloc] initWithActorSystem:actorSystemMock()];
+        actorRef = [[OSActorRef alloc] initWithActor:sut caller:self];
+    });
+    
+    it(@"should pass cancellation from client to service", ^() {
+        RXPromise *promise = [actorRef ask:[NSObject new]];
+        [[sut shouldEventually] receive:@selector(didCancel)];
+        [[sut shouldNotEventually] receive:@selector(didSucceed:)];
+        [[sut shouldNotEventually] receive:@selector(didFail:)];
+        dispatch_async(dispatch_get_global_queue(0, 0), ^{
+            [promise cancel];
+        });
+    });
+    
+    it(@"should receive error with RXPromise domain", ^() {
+        RXPromise *promise = [actorRef ask:[NSObject new]];
+        KWCaptureSpy *spy = [sut captureArgument:@selector(didReceiveErrorFromErrorBlock:) atIndex:0];
+        dispatch_semaphore_t dsema = dispatch_semaphore_create(0);
+        dispatch_async(dispatch_get_global_queue(0, 0), ^{
+            [promise cancel];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_global_queue(0, 0), ^{
+                dispatch_semaphore_signal(dsema);
+            });
+        });
+        dispatch_semaphore_wait(dsema, DISPATCH_TIME_FOREVER);
+        [[((NSError*)spy.argument).domain should] equal:@"RXPromise"];
+    });
+
+    it(@"should receive error with RXPromise domain and provided description", ^() {
+        RXPromise *promise = [actorRef ask:[NSObject new]];
+        KWCaptureSpy *spy = [sut captureArgument:@selector(didReceiveErrorFromErrorBlock:) atIndex:0];
+        dispatch_semaphore_t dsema = dispatch_semaphore_create(0);
+        dispatch_async(dispatch_get_global_queue(0, 0), ^{
+            [promise cancelWithReason:@"heyho"];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_global_queue(0, 0), ^{
+                dispatch_semaphore_signal(dsema);
+            });
+        });
+        dispatch_semaphore_wait(dsema, DISPATCH_TIME_FOREVER);
+        [[((NSError*)spy.argument).domain should] equal:@"RXPromise"];
+        [[((NSError*)spy.argument).localizedFailureReason should] equal:@"heyho"];
+    });
+    
+    it(@"should receive error provided to cancelWithReason:", ^() {
+        RXPromise *promise = [actorRef ask:[NSObject new]];
+        KWCaptureSpy *spy = [sut captureArgument:@selector(didReceiveErrorFromErrorBlock:) atIndex:0];
+        NSError *error = [NSError new];
+        dispatch_semaphore_t dsema = dispatch_semaphore_create(0);
+        dispatch_async(dispatch_get_global_queue(0, 0), ^{
+            [promise cancelWithReason:error];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_global_queue(0, 0), ^{
+                dispatch_semaphore_signal(dsema);
+            });
+        });
+        dispatch_semaphore_wait(dsema, DISPATCH_TIME_FOREVER);
+        [[spy.argument should] equal:error];
+    });
+    
+    
+    it(@"should pass success from client to service", ^() {
+        RXPromise * __unused promise = [actorRef ask:[NSObject new]];
+        [[sut shouldNotEventually] receive:@selector(didCancel)];
+        [[sut shouldEventually] receive:@selector(didSucceed:)];
+        [[sut shouldNotEventually] receive:@selector(didFail:)];
+        dispatch_async(dispatch_get_global_queue(0, 0), ^{
+            [sut finishCurrentPromiseWithResult:[NSObject new]];
+        });
+    });
+    
+    it(@"should pass error from client to service", ^() {
+        RXPromise * __unused promise = [actorRef ask:[NSObject new]];
+        [[sut shouldNotEventually] receive:@selector(didCancel)];
+        [[sut shouldNotEventually] receive:@selector(didSucceed:)];
+        [[sut shouldEventually] receive:@selector(didFail:)];
+        dispatch_async(dispatch_get_global_queue(0, 0), ^{
+            [sut finishCurrentPromiseWithError:[NSError new]];
+        });
+    });
+});
+SPEC_END

--- a/Tests/OSCancellableActor/OSCancellableActor.h
+++ b/Tests/OSCancellableActor/OSCancellableActor.h
@@ -1,0 +1,21 @@
+//
+//  OSCancellableActor.h
+//  Oscar
+//
+//  Created by Petro Korienev on 4/13/16.
+//  Copyright © 2016 Anastasiya Gorban. All rights reserved.
+//
+
+#import "OSActor.h"
+
+@interface OSCancellableActor : OSActor
+
+- (void)finishCurrentPromiseWithResult:(id)result;
+- (void)finishCurrentPromiseWithError:(NSError *)error;
+
+- (void)didSucceed:(id)result;
+- (void)didFail:(NSError *)error;
+- (void)didCancel;
+- (void)didReceiveErrorFromErrorBlock:(NSError *)error;
+
+@end

--- a/Tests/OSCancellableActor/OSCancellableActor.m
+++ b/Tests/OSCancellableActor/OSCancellableActor.m
@@ -1,0 +1,68 @@
+//
+//  OSCancellableActor.m
+//  Oscar
+//
+//  Created by Petro Korienev on 4/13/16.
+//  Copyright © 2016 Anastasiya Gorban. All rights reserved.
+//
+
+#import "OSCancellableActor.h"
+#import <RXPromise/RXPromise.h>
+
+@interface OSCancellableActor ()
+
+@property (nonatomic, strong) RXPromise *currentPromise;
+
+@end
+
+@implementation OSCancellableActor
+
+- (void)setup {
+    [self on:[NSObject class] doFuture:^RXPromise *(id message) {
+        return [self message:message];
+    }];
+}
+
+- (RXPromise *)message:(id)message {
+    self.currentPromise = [RXPromise new];
+    self.currentPromise.then(^id(id result) {
+        [self didSucceed:result];
+        return result;
+    }, ^id(NSError *error) {
+        if ([self.currentPromise isCancelled]) {
+            [self didCancel];
+        }
+        else {
+            [self didFail:error];
+        }
+        [self didReceiveErrorFromErrorBlock:error];
+        return error;
+    });
+    return self.currentPromise;
+}
+
+- (void)finishCurrentPromiseWithResult:(id)result {
+    [self.currentPromise fulfillWithValue:result];
+}
+
+- (void)finishCurrentPromiseWithError:(NSError *)error {
+    [self.currentPromise rejectWithReason:error];
+}
+
+- (void)didSucceed:(id)result {
+    self.currentPromise = nil;
+}
+
+- (void)didFail:(NSError *)error {
+    self.currentPromise = nil;
+}
+
+- (void)didCancel {
+    self.currentPromise = nil;
+}
+
+- (void)didReceiveErrorFromErrorBlock:(NSError *)error {
+    
+}
+
+@end


### PR DESCRIPTION
- Implemented binding of OSActorOperation promise(client) to handler promise(service) to pass cancellation
- Added method to OSActorRef to cancel (takePhraseBack)
- Added unit tests
- Bumped spec version
